### PR TITLE
Add debian archive repository for jessie-backports

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -83,6 +83,11 @@
     tags:
       - packages
 
+  - name: Add jessie-backports repository from debian archive
+    apt_repository:
+      repo: deb http://archive.debian.org/debian/ jessie-backports contrib main non-free
+      state: present
+
   - name: "Install extra dependencies from backports"
     apt:
       name:


### PR DESCRIPTION
Per https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
jessie backports has been moved to archive.debian.org, and thus needs a
custom debian repository entry to access it from now on.